### PR TITLE
:sparkles:Feat:전시상세페이지 우측 추천전시 구현

### DIFF
--- a/static/css/exhibition-detail.css
+++ b/static/css/exhibition-detail.css
@@ -94,3 +94,67 @@
 .show-accompanies:hover {
     background-color: silver;
 }
+
+/* 추천 전시 부분 recommend */
+.recommend-organizer {
+    background-color: #e8e5ff;
+    border-radius: 10px;
+    width: 23vmin;
+    height: 78vmin;
+    position:fixed; 
+    display:inline-block;
+    right:2%; /* 창에서 오른쪽 길이 */
+    top:15%; /* 창에서 위에서 부터의 높이 */
+    margin:0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 2vmin;
+}
+.rec-intro {
+    color: #6358DC;
+    font-weight: bold;
+}
+.recommend-organizer-small {
+    width: 20vmin;
+    margin-top: 7%;
+    height: 93%;
+    background-color: white;
+    border-radius: 10px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: space-evenly;
+}
+.one-by-one {
+    width: 17.5vmin;
+    height: 18%;
+    border-radius: 5px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+/* 추천전시의 이미지 */
+.rec-img-box {
+    width: 17.5vmin;
+    height: 85%;
+    border-radius: 5px;
+}
+.rec-img {
+    width: 100%;
+    height: 100%;
+    border-radius: 5px;
+    object-fit: cover;
+}
+/* 추천전시의 전시제목 */
+.rec-title {
+    height: 15%;
+    font-size: 0.4vmin;
+    font-weight: bold;
+    color: #6358DC;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    width: 100%;
+    margin-left: 0.5vmin;
+}

--- a/templates/exhibition-detail.html
+++ b/templates/exhibition-detail.html
@@ -51,7 +51,51 @@
         <!-- 이 부분에 리뷰 목록/ 동행글 목록 들어갈 자리 -->
         <!-- 이 부분에 리뷰 목록/ 동행글 목록 들어갈 자리 -->
     </div>
-
+    <div class="recommend-organizer">
+        <h6 class="rec-intro">그 외 전시 추천</h6>
+        <div class="recommend-organizer-small">
+            <div class="one-by-one">
+                <div class="rec-img-box">
+                    <a href="" target="" id="1-rec-img-anchor">
+                        <img class="rec-img" src="../static/img/default-img.jpg" id="1-rec-img">
+                    </a>                    
+                </div>
+                <span class="rec-title" id="1-rec-title">추천전시 제목</span>
+            </div>
+            <div class="one-by-one">
+                <div class="rec-img-box">
+                    <a href="" target="" id="2-rec-img-anchor">
+                        <img class="rec-img" src="../static/img/default-img.jpg" id="2-rec-img">
+                    </a>                    
+                </div>
+                <span class="rec-title" id="2-rec-title">추천전시 제목</span>
+            </div>
+            <div class="one-by-one">
+                <div class="rec-img-box">
+                    <a href="" target="" id="3-rec-img-anchor">
+                        <img class="rec-img" src="../static/img/default-img.jpg" id="3-rec-img">
+                    </a>                    
+                </div>
+                <span class="rec-title" id="3-rec-title">추천전시 제목</span>
+            </div>
+            <div class="one-by-one">
+                <div class="rec-img-box">
+                    <a href="" target="" id="4-rec-img-anchor">
+                        <img class="rec-img" src="../static/img/default-img.jpg" id="4-rec-img">
+                    </a>                    
+                </div>
+                <span class="rec-title" id="4-rec-title">추천전시 제목</span>
+            </div>
+            <div class="one-by-one">
+                <div class="rec-img-box">
+                    <a href="" target="" id="5-rec-img-anchor">
+                        <img class="rec-img" src="../static/img/default-img.jpg" id="5-rec-img">
+                    </a>                    
+                </div>
+                <span class="rec-title" id="5-rec-title">추천전시 제목</span>
+            </div>
+        </div>
+    </div>
 </body>
 
 </html>


### PR DESCRIPTION
전시 상세페이지 화면 우측에서 스크롤을 따라다니는
추천 전시란을 구현했습니다.

총 5개 데이터를 넣을 수 있으며 추천전시 한개마다 갖고 있는 id 선택자
이름은 유니크합니다.
a태그, img태그, span태그 id값은 1번부터 5번까지 각기 다릅니다.
그러나 class 선택자 이름은 디자인 상 5개의 카드가 동일하게 하기 위해
똑같은 이름을 갖고 있으니 주의해주세요~