### PR TITLE
:art:Style: 리뷰 조회 함수 이름 변경 #31

### DIFF
--- a/static/js/api.js
+++ b/static/js/api.js
@@ -124,6 +124,7 @@ export async function withdrawalAPI(user_id) {
     }
 }
 
+// 유저 정보 수정
 export async function userInfoEditAPI(data) {
     const response = await fetch(`${backendBaseURL}/users/`, {
         method: "PATCH",
@@ -147,14 +148,6 @@ export async function exhibitionPostingAPI(data) {
     return { response, responseJson }
 }
 
-
-// 리뷰 조회 API
-export async function getReviewAPI(exhibition_id) {
-    // const response = await fetch(`${backendBaseURL}/reviews/${exhibition_id}/`, { method: 'GET' })
-    const response = await fetch(`${backendBaseURL}/exhibitions/${exhibition_id}?select=reviews`, { method: 'GET' })
-    const responseJson = await response.json();
-    return { response, responseJson }
-
 // 전시회 수정
 export async function exhibitionPutAPI(exhibition_id, data) {
     const response = await fetch(`${backendBaseURL}/exhibitions/${exhibition_id}/`, {
@@ -175,4 +168,12 @@ export async function exhibitionDeleteAPI(exhibition_id) {
     })
     console.log(response)
     return response
+}
+
+// 리뷰 조회 API
+export async function reviewGetAPI(exhibition_id) {
+    // const response = await fetch(`${backendBaseURL}/reviews/${exhibition_id}/`, { method: 'GET' })
+    const response = await fetch(`${backendBaseURL}/exhibitions/${exhibition_id}?select=reviews`, { method: 'GET' })
+    const responseJson = await response.json();
+    return { response, responseJson }
 }

--- a/static/js/exhibition-detail.js
+++ b/static/js/exhibition-detail.js
@@ -1,7 +1,7 @@
 console.log('exhibition-detail 연결')
 
 
-import { getExhibitionAPI, exhibitionLikeAPI, payload, payloadParse, myPageAPI, getReviewAPI, backendBaseURL } from "./api.js";
+import { getExhibitionAPI, exhibitionLikeAPI, payload, payloadParse, myPageAPI, reviewGetAPI, backendBaseURL } from "./api.js";
 
 
 window.onload = function loadExhibition() {
@@ -109,7 +109,7 @@ function exhibitionReserve(link) {
 
 // 리뷰 버튼 눌렀을 때 실행되는 함수
 function review(exhibition_id) {
-    getReviewAPI(exhibition_id).then(({ response, responseJson }) => {
+    reviewGetAPI(exhibition_id).then(({ responseJson }) => {
         const reviewsDATA = responseJson.reviews.results
         console.log(reviewsDATA)
 


### PR DESCRIPTION
1. 다른 API 함수명에 맞춰서 함수명을 변경했습니다.
2. 전시회 CRUD 함수가 같이 있는 게 보기 좋을 것 같아서 리뷰 조회 함수를 맨 아래로 내렸습니다.
3. 리뷰 조회 함수에 }가 없어서 붙였습니다.