### PR TITLE
JS 확인 용 confirm, prompt 추가 

### DIFF
--- a/static/js/backoffice-main.js
+++ b/static/js/backoffice-main.js
@@ -143,11 +143,14 @@ window.onload = function loadExhibitions() {
 
 // 전시회 삭제 
 function exhibitionDelete(exhibition_id) {
-    deleteExhibitionAPI(exhibition_id).then((response) => {
-        // 전시회 삭제시 확인하기
-        alert('삭제완료')
-        window.location.reload()
-    })
+    // 전시회 삭제시 확인하기
+    if (confirm("정말 삭제하시겠습니까?")) {
+        deleteExhibitionAPI(exhibition_id).then((response) => {
+            console.log(response)
+            alert('삭제완료')
+            window.location.reload()
+        })
+    }
 }
 
 // 전시회 수정

--- a/static/js/my-page.js
+++ b/static/js/my-page.js
@@ -1,6 +1,6 @@
 console.log('my-page 연결')
 
-import { getUserInfoAPI, payloadParse, payload, frontendBaseURL, deleteUserInfoAPI, postExhibitionLikeAPI, backendBaseURL } from "./api.js";
+import { getUserInfoAPI, payloadParse, payload, frontendBaseURL, deleteUserInfoAPI, postExhibitionLikeAPI, backendBaseURL, postSignInAPI } from "./api.js";
 
 
 window.onload = function loadUserInfo() {
@@ -94,7 +94,7 @@ window.onload = function loadUserInfo() {
                     // 전시회 제목
                     const exhibitionTitle = document.createElement("span");
                     exhibitionTitle.setAttribute("class", "exhibition-title");
-                    exhibitionTitle.innerText = exhibition.info_name
+                    exhibitionTitle.innerHTML = exhibition.info_name
                     exhibitionInfoBox.appendChild(exhibitionTitle);
 
                     // 전시회 기간
@@ -153,20 +153,38 @@ window.onload = function loadUserInfo() {
 }
 
 function profileEdit(user_id) {
-    console.log('프로필 수정', user_id)
-    window.location.href = `${frontendBaseURL}/templates/updated-user.html?user_id=${user_id}`
+    console.log('프로필 수정', payloadParse)
+    // 일반 로그인만 비밀번호 확인하기 
+    if (payloadParse.signin_type == 'normal') {
+        let data = {
+            "email": payloadParse.email,
+            "password": prompt('비밀번호를 입력해주세요')
+        }
+        postSignInAPI(data).then(({ response, responseJson }) => {
+            if (response.status == 200) {
+                window.location.href = `${frontendBaseURL}/templates/updated-user.html?user_id=${user_id}`
+            } else {
+                alert('비밀번호가 일치하지 않습니다')
+            }
+        })
+    } else {
+        window.location.href = `${frontendBaseURL}/templates/updated-user.html?user_id=${user_id}`
+    }
 }
 
 function withdrawal(user_id) {
     console.log('회원 탈퇴', user_id)
-    deleteUserInfoAPI(user_id).then(({ response, responseJson }) => {
-        if (response.status == 200) {
-            localStorage.removeItem("access")
-            localStorage.removeItem("refresh")
-            localStorage.removeItem("payload")
-            location.reload();
-        }
-    })
+    if (confirm("정말 탈퇴하시겠습니까?")) {
+        deleteUserInfoAPI(user_id).then(({ response, responseJson }) => {
+            if (response.status == 200) {
+                alert("탈퇴가 완료됐습니다.")
+                localStorage.removeItem("access")
+                localStorage.removeItem("refresh")
+                localStorage.removeItem("payload")
+                location.reload();
+            }
+        })
+    }
 }
 
 

--- a/static/js/updated-user.js
+++ b/static/js/updated-user.js
@@ -35,12 +35,14 @@ function userInfoEdit() {
     const gender = document.getElementById('gender').value;
     const profileImage = document.getElementById('profileImage').files[0]
     const bio = document.getElementById('bio').value;
-    if (!password | !passwordCheck | password != passwordCheck) {
-        alert('올바른 비밀번호를 입력해주세요')
+    if (password != passwordCheck) {
+        alert('비밀번호가 일치하지 않습니다')
     } else {
         const data = new FormData();
         data.append("nickname", nickname)
-        data.append("password", password)
+        if (password) {
+            data.append("password", password)
+        }
         data.append("gender", gender)
         if (profileImage) {
             data.append("profile_image", profileImage)


### PR DESCRIPTION
회원 정보 수정시 일반 로그인이면 prompt로
비밀번호 확인 후 정보 수정으로 이동
```javascript
let data = {
            "email": payloadParse.email,
            "password": prompt('비밀번호를 입력해주세요')
        }
        postSignInAPI(data).then(({ response, responseJson }) => {
            if (response.status == 200) {
                window.location.href = `${frontendBaseURL}/templates/updated-user.html?user_id=${user_id}`
```
prompt로 비밀번호를 입력받고 payload의 email과 함께 로그인 status확인

비밀번호 확인 로직이 추가되면서 updated-user 비밀번호 빈값 체크 제거
기존 코드
```javascript
if (!password | !passwordCheck | password != passwordCheck) {
        alert('올바른 비밀번호를 입력해주세요')
```
수정된 코드
```javascript
if (password != passwordCheck) {
        alert('비밀번호가 일치하지 않습니다')
```
회원 탈퇴시 confirm으로 확인하기