### PR TITLE
:sparkles:Feat: 리뷰 작성/수정 시 입력에 따른 경고창 추가 및 함수 제거 #28

### DIFF
--- a/static/js/review-editing.js
+++ b/static/js/review-editing.js
@@ -179,7 +179,8 @@ export function updateReview(reviewBox, reviewData) {
                     deleteReview(reviewBox, responseJson.data)
                 }
             } else {
-                alert(responseJson.message)
+                alert(responseJson.content && "내용없이 글을 작성할 수 없습니다."
+                    || responseJson.rating && "별점을 선택하십시오.")
                 textareaElement.style.display = "block"
             }            
         })

--- a/static/js/review-posting.js
+++ b/static/js/review-posting.js
@@ -109,8 +109,17 @@ export function postReview(exhibition_id) {
             rvPostingBtn.setAttribute("class", "rp-review-posting-btn")
             rvPostingBtn.setAttribute("id", "rvPostingBtn")
             rvPostingBtn.addEventListener("click", function () {
-                handleReviewPosting(exhibition_id)
-                review(exhibition_id)
+                postReviewAPI(exhibition_id, reviewInputInfo()).then(({ response, responseJson }) => {
+                    if (response.status == 201) {
+                        addNewReview(responseJson.data)
+                        review(exhibition_id)
+                        review(exhibition_id)   // 두 번 실행해야 새로고침 없이 조회 가능
+                        alert("글이 등록되었습니다.")
+                    } else {
+                        alert(responseJson.content && "내용없이 글을 작성할 수 없습니다."
+                            || responseJson.rating && "별점을 선택하십시오.")
+                    }
+                })
             })
             rvPostingBtn.innerText = "입력완료"
             row3InPurple.appendChild(rvPostingBtn)
@@ -150,18 +159,6 @@ function reviewInputInfo() {
         data.append("image", rvImage)
     }
     return data
-}
-
-// 입력완료 버튼 시 실행되는 함수
-function handleReviewPosting(exhibition_id) {
-    postReviewAPI(exhibition_id, reviewInputInfo()).then(({ response, responseJson }) => {
-        if (response.status == 201) {
-            addNewReview(responseJson.data)
-            review(exhibition_id)
-        } else {
-            alert(responseJson.message)
-        }
-    })
 }
 
 // 방금 작성한 리뷰 목록에 추가하기
@@ -254,7 +251,7 @@ function addNewReview(reviewData) {
             reviewUpdateBtn.innerText = "수정"
             reviewUpdateBtn.addEventListener("click", function () {
                 if (isEditingReview) {
-                    alert("수정하고 있는 리뷰를 저장 또는 취소 후 클릭하십시오.")
+                    alert("수정하고 있는 글을 저장 또는 취소 후 클릭하십시오.")
                 } else {
                     updateReview(grayBox, reviewData)
                 }


### PR DESCRIPTION
1. 사용자가 입력한 결과에 따라 게시글 작성/수정에 실패할 경우 그에 맞는 경고창이 뜨도록 했습니다.
2. 입력완료 버튼 클릭 시 실행되는 함수를 삭제하고, 해당 함수의 내용을 입력완료 버튼 클릭 시 바로 동작하도록 하였습니다. 이에 대한 효과로 동행구하기 글 작성에 실패한 경우 작성창이 닫히지 않고 그대로 남아 있음으로써 사용자가 느낄 수 있는 불편함을 개선하였습니다.
3. 수정 중에 다른 버튼을 눌렀을 때 메시지를 통일하였습니다.(리뷰 -> 글)