### PR TITLE
:sparkles:Feat: 백엔드에서 데이터 불러오는 부분 변경에 따른 수정사항 #31

### DIFF
--- a/static/js/review-posting.js
+++ b/static/js/review-posting.js
@@ -1,5 +1,5 @@
 import { backendBaseURL, payload, payloadParse, postReviewAPI } from "./api.js";
-import { review, deleteReview } from "./review.js";
+import { getReview, deleteReview } from "./review.js";
 import { isEditingReview, updateReview } from "./review-editing.js"
 
 let starValue = 0;
@@ -112,8 +112,8 @@ export function postReview(exhibition_id) {
                 postReviewAPI(exhibition_id, reviewInputInfo()).then(({ response, responseJson }) => {
                     if (response.status == 201) {
                         addNewReview(responseJson.data)
-                        review(exhibition_id)
-                        review(exhibition_id)   // 두 번 실행해야 새로고침 없이 조회 가능
+                        getReview(exhibition_id)
+                        getReview(exhibition_id)   // 두 번 실행해야 새로고침 없이 조회 가능
                         alert("글이 등록되었습니다.")
                     } else {
                         alert(responseJson.content && "내용없이 글을 작성할 수 없습니다."

--- a/static/js/review.js
+++ b/static/js/review.js
@@ -8,7 +8,7 @@ let isRpBtnRendered = false;
 
 //----------------------------------------------------------------조회 및 삭제----------------------------------------------------------------
 // 이용후기 버튼 눌렀을 때 실행되는 함수
-export function review(exhibition_id) {
+export function getReview(exhibition_id) {
     if (isEditingReview || isEditingAccompany) {
         alert("수정하고 있는 글을 저장 또는 취소 후 클릭하십시오.")
     } else {
@@ -49,7 +49,7 @@ export function review(exhibition_id) {
             }
             if (!isReviewsRendered) {
                 getReviewAPI(exhibition_id).then(({ responseJson }) => {
-                    const reviewsDATA = responseJson.reviews.results            
+                    const reviewsDATA = responseJson.reviews         
 
                     // 후기 목록
                     reviewsDATA.forEach(review => {      


### PR DESCRIPTION
백엔드에서 리뷰 페이지네이션에 사라짐에 따라 조회 시 reviews.result가
아닌 reviews로 접근 가능하여 수정함.
이용후기 버튼 클릭 시 실행되는 함수명을 review()에서 getReview()로
변경함(다른 함수명과 통일함)