### PR TITLE
:sparkles:Feat: 백엔드에서 데이터 불러오는 부분 변경에 따른 수정사항 #34

### DIFF
--- a/static/js/accompany-posting.js
+++ b/static/js/accompany-posting.js
@@ -1,5 +1,5 @@
 import { payload, payloadParse, postAccompanyAPI } from "./api.js";
-import { accompany, deleteAccompany } from "./accompany.js";
+import { getAccompany, deleteAccompany } from "./accompany.js";
 import { isEditingAccompany, updateAccompany } from "./accompany-editing.js";
 
 //----------------------------------------------------------------작성----------------------------------------------------------------
@@ -94,8 +94,8 @@ export function accompanyPosting(exhibition_id){
                 postAccompanyAPI(exhibition_id, accompanyInputInfo()).then(({ response, responseJson }) => {
                     if (response.status == 201) {
                         addNewAccompany(responseJson.data)
-                        accompany(exhibition_id)
-                        accompany(exhibition_id)   // 두 번 실행해야 새로고침 없이 조회 가능
+                        getAccompany(exhibition_id)
+                        getAccompany(exhibition_id)   // 두 번 실행해야 새로고침 없이 조회 가능
                         alert("글이 등록되었습니다.")
                     } else {
                         alert(responseJson.content && "내용없이 글을 작성할 수 없습니다."

--- a/static/js/accompany.js
+++ b/static/js/accompany.js
@@ -8,7 +8,7 @@ let isApBtnRenderd = false;
 
 //----------------------------------------------------------------조회 및 삭제----------------------------------------------------------------
 // 동행구해요! 버튼 눌렀을 때 실행되는 함수
-export function accompany(exhibition_id){
+export function getAccompany(exhibition_id){
     if (isEditingAccompany || isEditingReview) {
         alert("수정하고 있는 글을 저장 또는 취소 후 클릭하십시오.")
     } else {
@@ -49,7 +49,7 @@ export function accompany(exhibition_id){
             }
             if (!isAccompaniesRendered) {
                 getAccompanyAPI(exhibition_id).then(({ responseJson }) => {
-                    const accompaniesDATA = responseJson.accompanies.results
+                    const accompaniesDATA = responseJson.accompanies
                     console.log(accompaniesDATA)
 
                     const accompanyList = document.getElementById("accompanyList")


### PR DESCRIPTION
백엔드에서 동행글 페이지네이션이 사라짐에 따라 조회 시 accompanies.result가 아닌 accompanies로 접근 가능하여 수정함.
동행구해요! 버튼 클릭 시 실행되는 함수명을 accompany()에서 getAccompany()로 변경함(다른 함수명과 통일함)