### PR TITLE
:art:Style:화면구현 수정

### DIFF
--- a/static/css/accompany-apply-posting.css
+++ b/static/css/accompany-apply-posting.css
@@ -5,9 +5,6 @@
     align-items: center;
     justify-content: center;
 }
-body:last-child {
-    margin-bottom: 50vmin;
-}
 /* 구간 타이틀: 동행글 목록 */
 .welcome-title {
     color: #6358DC;

--- a/static/js/api.js
+++ b/static/js/api.js
@@ -1,12 +1,12 @@
 console.log('api 연결')
 
 // 배포용 URL
-export const frontendBaseURL = "https://b4-exhibitions-front.netlify.app";
-export const backendBaseURL = "https://www.b4-exhibitions.shop/api";
+// export const frontendBaseURL = "https://b4-exhibitions-front.netlify.app";
+// export const backendBaseURL = "https://www.b4-exhibitions.shop/api";
 
 // 로컬용 URL
-// export const frontendBaseURL = "http://127.0.0.1:5500";
-// export const backendBaseURL = "http://127.0.0.1:8000/api";
+export const frontendBaseURL = "http://127.0.0.1:5500";
+export const backendBaseURL = "http://127.0.0.1:8000/api";
 
 export const payload = localStorage.getItem("payload")
 export const payloadParse = JSON.parse(payload);

--- a/static/js/footer.js
+++ b/static/js/footer.js
@@ -1,16 +1,16 @@
 console.log('footer 연결')
 
 document.getElementById("footer").innerHTML = `
-<span class="copyright">ⓒExhibition Now</span>
+    <span class="copyright">ⓒExhibition Now</span>
     <span class="name-links">
-        <a href="https://github.com/sdoram" class="name-link">김세만</a>
+        <a href="https://github.com/sdoram" class="name-link" target="_blank">김세만</a>
         <span>|</span>
-        <a href="https://github.com/goodminjeong" class="name-link">구민정</a>
+        <a href="https://github.com/goodminjeong" class="name-link" target="_blank">구민정</a>
         <span>|</span>
-        <a href="https://github.com/banghyunjae" class="name-link">방현재</a>
+        <a href="https://github.com/banghyunjae" class="name-link" target="_blank">방현재</a>
         <span>|</span>
-        <a href="https://github.com/mijinleee" class="name-link">이미진</a>
+        <a href="https://github.com/mijinleee" class="name-link" target="_blank">이미진</a>
         <span>|</span>
-        <a href="https://github.com/OCmonet" class="name-link">이동현</a>
+        <a href="https://github.com/OCmonet" class="name-link" target="_blank">이동현</a>
     </span>
 `;

--- a/templates/exhibition-detail.html
+++ b/templates/exhibition-detail.html
@@ -22,6 +22,7 @@
     <link rel="stylesheet" href="../static/css/accompany-posting.css">
     <link rel="stylesheet" href="../static/css/footer.css">
     <link rel="stylesheet" href="../static/css/accompany-apply-posting.css">
+    <script type="module" src="../static/js/footer.js"></script>
     <script type="module" src="../static/js/navbar.js"></script>
     <script type="module" src="../static/js/exhibition-detail.js"></script>
     <title>지금은 전시상황! | 상세보기</title>
@@ -107,6 +108,5 @@
         </div>
     </div>
     <div class="footer" id="footer"></div>
-    <script type="module" src="../static/js/footer.js"></script>
 </body>
 </html>

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -1,14 +1,14 @@
 <div class="footer" id="footer">
     <span class="copyright">ⓒExhibition Now</span>
     <span class="name-links">
-        <a href="https://github.com/sdoram" class="name-link">김세만</a>
+        <a href="https://github.com/sdoram" class="name-link" target="_blank">김세만</a>
         <span>|</span>
-        <a href="https://github.com/goodminjeong" class="name-link">구민정</a>
+        <a href="https://github.com/goodminjeong" class="name-link" target="_blank">구민정</a>
         <span>|</span>
-        <a href="https://github.com/banghyunjae" class="name-link">방현재</a>
+        <a href="https://github.com/banghyunjae" class="name-link" target="_blank">방현재</a>
         <span>|</span>
-        <a href="https://github.com/mijinleee" class="name-link">이미진</a>
+        <a href="https://github.com/mijinleee" class="name-link" target="_blank">이미진</a>
         <span>|</span>
-        <a href="https://github.com/OCmonet" class="name-link">이동현</a>
+        <a href="https://github.com/OCmonet" class="name-link" target="_blank">이동현</a>
     </span>
 </div>


### PR DESCRIPTION
1. 전시상세 페이지에서 푸터 밑에 하얀색 공백이 들어가는 현상 수정
2. 푸터에서 개발자 이름 클릭 시 깃허브 링크가 열릴 때, 새 창에서 열리게 끔 수정