### PR TITLE
:bug:Fix: 일반 로그인 시 돌아갈 페이지 수정 및 알림창 삭제 #10

### DIFF
--- a/static/js/signin.js
+++ b/static/js/signin.js
@@ -35,12 +35,11 @@ function handleSignIn() {
     postSignInAPI(data).then(({ response, responseJson }) => {
         if (response.status == 200) {
             setLocalStorage(responseJson);
-            alert('로그인에 성공했습니다.');
-            window.location.href = window.history.go(-1)
+            window.history.go(-1)
         } else {
             alert(responseJson.email && "이메일을 입력해주세요"
                 || responseJson.password && "비밀번호를 입력해주세요" ||
-                responseJson.detail && "회원 정보를 찾을 수 없습니다", window.location.reload())
+                responseJson.detail && "이메일 또는 비밀번호를 확인해 주세요", window.location.reload())
         }
     })
 }
@@ -69,7 +68,6 @@ if (payload) {
     googleAPI(google_token).then(({ response, responseJson }) => {
         if (response.status == 200) {
             setLocalStorage(responseJson)
-            alert('구글 계정으로 로그인 되었습니다.');
             window.location.href = window.history.go(-3)
         } else {
             alert(responseJson.message);


### PR DESCRIPTION
일반 로그인 시 돌아가는 페이지를 찾을 수 없다고 떠서 수정함
로그인 성공 시 알림창 지움(구글 로그인 시 알림창으로 인해 access_token이 url에 보이는 시간이 늘어남)